### PR TITLE
Add workflows for release promotion

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,0 +1,23 @@
+name: Create release promotion pull request
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  release-promotion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Create a pull request from develop to master
+      - name: Create Pull Request
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create --base master --head develop \
+            --title "Merge from develop to master" \
+            --body "This is an automated pull request created by GitHub Actions." \
+            --reviewer matinlotfali \
+            --reviewer mistyron

--- a/.github/workflows/master-fast-forward.yml
+++ b/.github/workflows/master-fast-forward.yml
@@ -1,0 +1,23 @@
+name: Fast forward master if develop is approved
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  fast_forward_job:
+    name: Fast Forward
+    if: github.event.pull_request.base.ref == 'master' && github.event.review.state == 'approved'  
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+        
+      - name: Fast Forward PR
+        run: |
+          git merge origin/develop --ff-only
+          git push


### PR DESCRIPTION
In this pull request, I am adding workflows similar to https://github.com/MistySOM/meta-mistysom/pull/37

The only difference is that there is **no** release submission, rather, it is deployed on wiki.mistysom.com.