### PR TITLE
Add the missing Using_GPIOs.md in SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -52,6 +52,7 @@
 
 * [Read values from ADCs](content/readADCs.md)
 * [GPIO Pins](content/GPIOPins.md)
+   * [How to use GPIOs](content/Using_GPIOs.md)
 * [How to set pin mux](content/pinmux.md)
 * [Setup WiFi](content/SetupWifi.md)
 * [How To Set Up Socket CAN](content/HowToSetUpSocketCANInterface.md)


### PR DESCRIPTION
The link https://wiki.mistysom.com/content/Using_GPIOs.html is unreachable maybe because it is not part of the SUMMARY.md and therefore it is not being built.